### PR TITLE
Update to Protocol Buffers 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>2.5.0</version>
+            <version>3.2.0</version>
         </dependency>
     </dependencies>
 
@@ -53,14 +53,14 @@
             <plugin>
                 <groupId>com.github.os72</groupId>
                 <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.1.0.2</version>
+                <version>3.2.0.1</version>
                 <executions>
                     <execution>
                         <goals>
                             <goal>run</goal>
                         </goals>
                         <configuration>
-                            <protocVersion>2.5.0</protocVersion>
+                            <protocVersion>3.2.0</protocVersion>
                             <cleanOutputFolder>true</cleanOutputFolder>
                         </configuration>
                     </execution>

--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+syntax = "proto2";
+
 package com.facebook.hive.orc;
 
 option java_package = "com.facebook.presto.orc.proto";

--- a/src/main/protobuf/orc_proto.proto
+++ b/src/main/protobuf/orc_proto.proto
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+syntax = "proto2";
+
 package orc.proto;
 
 option java_package = "com.facebook.presto.orc.proto";


### PR DESCRIPTION
This version preserves the IOException causal chain when decoding.