### PR TITLE
Add Fields Needed for Flattened Maps to DWRF Spec

### DIFF
--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -94,11 +94,20 @@ message Stream {
         STRIDE_DICTIONARY = 8;
         STRIDE_DICTIONARY_LENGTH = 9;
         BLOOM_FILTER_UTF8 = 10;
+        IN_MAP = 11;
     }
     required Kind kind = 1;
     optional uint32 column = 2;
     optional uint64 length = 3;
     optional bool useVInts = 4 [default = true];
+    optional uint32 sequence = 6;
+}
+
+message KeyInfo {
+  // this covers all width of integers including byte, short, int and long
+  optional int64 intKey = 1;
+  // this covers binary key or utf8 string
+  optional bytes bytesKey = 2;
 }
 
 message ColumnEncoding {
@@ -107,9 +116,13 @@ message ColumnEncoding {
         DICTIONARY = 1;
         DIRECT_V2 = 2;
         DICTIONARY_V2 = 3;
+        MAP_FLAT = 4;
     }
     required Kind kind = 1;
     optional uint32 dictionarySize = 2;
+    optional uint32 column = 3;
+    optional uint32 sequence = 4;
+    optional KeyInfo key = 5;
 }
 
 message StripeFooter {


### PR DESCRIPTION
Update the DWRF Protobuf spec to include fields added to support Flattened Maps.

Flattened Maps is a new way of laying out maps in DWRF so that the values for each key are effectively stored in their own column.

Specifically this adds
- IN_MAP as a Stream.Kind  This type of Stream contains bits indicating whether or not a key is present in the map.
- A KeyInfo message which contains a key in the map
- MAP_FLAT as a ColumnEncoding.Kind to indicate the map was flattened
- sequence is added to Stream.  The value in a map is represented as a single "column", this value is used to distinguish streams for values associated with different keys.
- column and sequence are added to ColumnEncoding to allow it to map to Streams
- keyInfo is added to ColumnEncoding to store the key associated with the ColumnEncoding for a "column" of values.