### PR TITLE
Update to current airbase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>59</version>
+        <version>88</version>
     </parent>
 
     <groupId>com.facebook.presto.orc</groupId>


### PR DESCRIPTION
Currently mvn install fails with:
`
[ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:2.5.2:findbugs (findbugs) on project orc-protobuf: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:2.5.2:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginConfigurationException
`