### PR TITLE
Add FileStatistics to dwrfproto

### DIFF
--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -185,6 +185,11 @@ message UserMetadataItem {
     required bytes value = 2;
 }
 
+// Statistics for a sub tree of the schema in depth first traveral order
+message FileStatistics {
+    repeated ColumnStatistics statistics = 1;
+}
+
 message EncryptionGroup {
     // Sub trees in the schema that encryption should be applied
     // Sub tree is identified by its root id


### PR DESCRIPTION
It is necessary for encryption, and was accidentally left out before.