### PR TITLE
Fix stats in encryption group

### DIFF
--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -203,7 +203,8 @@ message EncryptionGroup {
     optional bytes keyMetadata = 2;
 
     // encrypted columns stats (serialized FileStatistics)
-    optional bytes statistics = 3;
+    // one FileStatistics object per node
+    repeated bytes statistics = 3;
 }
 
 message Encryption {


### PR DESCRIPTION
Should be repeated bytes so that there is one filestatistics object per
node.