### PR TITLE
Add Size Stats to Dwrf

### DIFF
--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -50,6 +50,15 @@ message BinaryStatistics {
     optional sint64 sum = 1;
 }
 
+message MapEntryStatistics {
+    optional KeyInfo key = 1;
+    optional ColumnStatistics stats = 2;
+}
+
+message MapStatistics {
+    repeated MapEntryStatistics stats = 1;
+}
+
 message ColumnStatistics {
     optional uint64 numberOfValues = 1;
     optional IntegerStatistics intStatistics = 2;
@@ -58,6 +67,11 @@ message ColumnStatistics {
     optional BucketStatistics bucketStatistics = 5;
     optional bool hasNull = 6;
     optional BinaryStatistics binaryStatistics = 7;
+    // uncompressed size
+    optional uint64 rawSize = 8;
+    // compressed size, only used for file statistics.
+    optional uint64 size = 9;
+    optional MapStatistics mapStatistics = 10;
 }
 
 message RowIndexEntry {


### PR DESCRIPTION
RawSize - Uncompressed size of a column.
Size - Compressed size of a column, only set at file level.
MapStatistics - Used for flat maps, adding this as it will be
required by flat map writer work later.