### PR TITLE
Add TIMESTAMP_MICROSECONDS type

### DIFF
--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -175,6 +175,7 @@ message Type {
         MAP = 11;
         STRUCT = 12;
         UNION = 13;
+        TIMESTAMP_MICROSECONDS = 14;
     }
     required Kind kind = 1;
     repeated uint32 subtypes = 2 [packed = true];
@@ -296,6 +297,7 @@ enum PrimitiveType {
     INTERVAL_YEAR_MONTH = 15;
     INTERVAL_DAY_TIME = 16;
     UNKNOWN = 17;
+    TIMESTAMP_MICROSECONDS = 18;
 }
 
 message TypeStorage {


### PR DESCRIPTION
TIMESTAMP_MICROSECONDS type is now available in Presto types to be able to support microseconds (using TIMESTAMP_MICROSECONDS type) in addition to milliseconds (using TIMESTAMP type) in Presto ORC

This change adds TIMESTAMP_MICROSECONDS type to DWRF definition as part of introducing microsecond support in Presto ORC via types. 