### PR TITLE
Include optional timezone field in StripeFooter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>98</version>
+        <version>108</version>
     </parent>
 
     <groupId>com.facebook.presto.orc</groupId>

--- a/src/main/protobuf/dwrf_proto.proto
+++ b/src/main/protobuf/dwrf_proto.proto
@@ -157,6 +157,7 @@ message StripeFooter {
     // Encrypted column metadata. Number of encrypted groups should match
     // that in the file footer
     repeated bytes encryptedGroups = 3;
+    optional string writerTimezone = 4;
 }
 
 message Type {


### PR DESCRIPTION
Required for Hive 4.0.1 Upgrade: https://github.com/prestodb/presto/pull/24571

The changes have already been tested with CI in the above-linked PR.